### PR TITLE
Feature/passthru test id prop

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  presets: ["module:metro-react-native-babel-preset"],
+};
+

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+  preset: "react-native",
+  clearMocks: true,
+  coverageDirectory: "./coverage",
+  moduleNameMapper: { },
+  setupFiles: [
+  ],
+  setupFilesAfterEnv: [],
+  testEnvironment: "node",
+  transformIgnorePatterns: ["node_modules/(?!@ngrx|(?!deck.gl)|ng-dynamic)"],
+  verbose: true,
+  coverageThreshold: {
+    global: {
+      statements: 100,
+      branches: 100,
+      functions: 100,
+      line: 100,
+    },
+  },
+};
+

--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/rtgstudio/rtg-react-native-social-buttons/issues"
   },
   "dependencies": {
-    "prop-types": "^15.7.2"
+    "prop-types": "^15.0 || ^16.0"
   },
   "description": "Social Buttons for React-Native",
   "devDependencies": {
     "prettier": "^1.17.0",
-    "react": "16.5.0",
-    "react-native": "^0.57.1"
+    "react": "~17.0.2",
+    "react-native": "0.65.1"
   },
   "files": [
     "src"

--- a/package.json
+++ b/package.json
@@ -51,5 +51,10 @@
     "type": "git",
     "url": "git+https://github.com/rtgstudio/rtg-react-native-social-buttons.git"
   },
+  "scripts": {
+    "prettyone": "prettier --write ",
+    "prettier": "prettier --write **/*.js",
+    "test": "jest --coverage --colors "
+  },
   "version": "0.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
   },
   "description": "Social Buttons for React-Native",
   "devDependencies": {
+    "@testing-library/jest-native": "^4.0.2",
+    "@testing-library/react-native": "^7.2.0",
+    "jest": "^27.1.0",
+    "jest-each": "^27.1.0",
     "prettier": "^1.17.0",
     "react": "~17.0.2",
     "react-native": "0.65.1"

--- a/src/SocialButtons.js
+++ b/src/SocialButtons.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import {
-  View, Text,
+  View,
+  Text,
   TouchableOpacity,
   StyleSheet,
   Image,
@@ -13,11 +14,15 @@ export default class SocialButton extends Component {
   }
 
   renderFaceBookButton(buttonText, opacity, height, width) {
-
     return (
-      <TouchableOpacity style={[styles.FacebookStyle, { height, width }]} activeOpacity={opacity} onPress={this.props.action} testID={this.props.testID}>
+      <TouchableOpacity
+        style={[styles.FacebookStyle, { height, width }]}
+        activeOpacity={opacity}
+        onPress={this.props.action}
+        testID={this.props.testID}
+      >
         <Image
-          source={require('./images/facebook.png')}
+          source={require("./images/facebook.png")}
           style={styles.ImageIconStyle}
         />
         <View style={styles.SeparatorLine} />
@@ -28,9 +33,14 @@ export default class SocialButton extends Component {
 
   renderGoogleButton(buttonText, opacity, height, width) {
     return (
-      <TouchableOpacity style={[styles.GooglePlusStyle, { height, width }]} activeOpacity={opacity} onPress={this.props.action} testID={this.props.testID}>
+      <TouchableOpacity
+        style={[styles.GooglePlusStyle, { height, width }]}
+        activeOpacity={opacity}
+        onPress={this.props.action}
+        testID={this.props.testID}
+      >
         <Image
-          source={require('./images/google-plus.png')}
+          source={require("./images/google-plus.png")}
           style={styles.ImageIconStyle}
         />
         <View style={styles.SeparatorLine} />
@@ -41,9 +51,14 @@ export default class SocialButton extends Component {
 
   renderGithubButton(buttonText, opacity, height, width) {
     return (
-      <TouchableOpacity style={[styles.GithubStyle, { height, width }]} activeOpacity={opacity} onPress={this.props.action} testID={this.props.testID}>
+      <TouchableOpacity
+        style={[styles.GithubStyle, { height, width }]}
+        activeOpacity={opacity}
+        onPress={this.props.action}
+        testID={this.props.testID}
+      >
         <Image
-          source={require('./images/github.png')}
+          source={require("./images/github.png")}
           style={styles.ImageIconStyle}
         />
         <View style={styles.SeparatorLine} />
@@ -54,9 +69,14 @@ export default class SocialButton extends Component {
 
   renderTwitterButton(buttonText, opacity, height, width) {
     return (
-      <TouchableOpacity style={[styles.TwitterStyle, { height, width }]} activeOpacity={opacity} onPress={this.props.action} testID={this.props.testID}>
+      <TouchableOpacity
+        style={[styles.TwitterStyle, { height, width }]}
+        activeOpacity={opacity}
+        onPress={this.props.action}
+        testID={this.props.testID}
+      >
         <Image
-          source={require('./images/twitter.png')}
+          source={require("./images/twitter.png")}
           style={styles.ImageIconStyle}
         />
         <View style={styles.SeparatorLine} />
@@ -67,9 +87,14 @@ export default class SocialButton extends Component {
 
   renderAmazonButton(buttonText, opacity, height, width) {
     return (
-      <TouchableOpacity style={[styles.AmazonStyle, { height, width }]} activeOpacity={opacity} onPress={this.props.action} testID={this.props.testID}>
+      <TouchableOpacity
+        style={[styles.AmazonStyle, { height, width }]}
+        activeOpacity={opacity}
+        onPress={this.props.action}
+        testID={this.props.testID}
+      >
         <Image
-          source={require('./images/amazon.png')}
+          source={require("./images/amazon.png")}
           style={styles.ImageIconStyle}
         />
         <View style={styles.SeparatorLine} />
@@ -80,9 +105,14 @@ export default class SocialButton extends Component {
 
   renderMicrosoftButton(buttonText, opacity, height, width) {
     return (
-      <TouchableOpacity style={[styles.MicrosoftStyle, { height, width }]} activeOpacity={opacity} onPress={this.props.action} testID={this.props.testID}>
+      <TouchableOpacity
+        style={[styles.MicrosoftStyle, { height, width }]}
+        activeOpacity={opacity}
+        onPress={this.props.action}
+        testID={this.props.testID}
+      >
         <Image
-          source={require('./images/windows.png')}
+          source={require("./images/windows.png")}
           style={styles.ImageIconStyle}
         />
         <View style={styles.SeparatorLine} />
@@ -93,9 +123,14 @@ export default class SocialButton extends Component {
 
   renderLinkedinButton(buttonText, opacity, height, width) {
     return (
-      <TouchableOpacity style={[styles.LinkdnStyle, { height, width }]} activeOpacity={opacity} onPress={this.props.action} testID={this.props.testID}>
+      <TouchableOpacity
+        style={[styles.LinkdnStyle, { height, width }]}
+        activeOpacity={opacity}
+        onPress={this.props.action}
+        testID={this.props.testID}
+      >
         <Image
-          source={require('./images/linkedin.png')}
+          source={require("./images/linkedin.png")}
           style={styles.ImageIconStyle}
         />
         <View style={styles.SeparatorLine} />
@@ -105,162 +140,197 @@ export default class SocialButton extends Component {
   }
 
   render() {
-
-    if (this.props.type == 'facebook') {
+    if (this.props.type == "facebook") {
       return (
         <View>
-          {this.renderFaceBookButton(this.props.text, this.props.opacity, this.props.height, this.props.width)}
+          {this.renderFaceBookButton(
+            this.props.text,
+            this.props.opacity,
+            this.props.height,
+            this.props.width
+          )}
         </View>
       );
-    } else if (this.props.type == 'amazon') {
+    } else if (this.props.type == "amazon") {
       return (
         <View>
-          {this.renderAmazonButton(this.props.text, this.props.opacity, this.props.height, this.props.width)}
+          {this.renderAmazonButton(
+            this.props.text,
+            this.props.opacity,
+            this.props.height,
+            this.props.width
+          )}
         </View>
-      )
-    } else if (this.props.type == 'linkedin') {
+      );
+    } else if (this.props.type == "linkedin") {
       return (
         <View>
-          {this.renderLinkedinButton(this.props.text, this.props.opacity, this.props.height, this.props.width)}
-        </View>)
-    } else if (this.props.type == 'google') {
+          {this.renderLinkedinButton(
+            this.props.text,
+            this.props.opacity,
+            this.props.height,
+            this.props.width
+          )}
+        </View>
+      );
+    } else if (this.props.type == "google") {
       return (
         <View>
-          {this.renderGoogleButton(this.props.text, this.props.opacity, this.props.height, this.props.width)}
-        </View>)
-    } else if (this.props.type == 'microsoft') {
+          {this.renderGoogleButton(
+            this.props.text,
+            this.props.opacity,
+            this.props.height,
+            this.props.width
+          )}
+        </View>
+      );
+    } else if (this.props.type == "microsoft") {
       return (
         <View>
-          {this.renderMicrosoftButton(this.props.text, this.props.opacity, this.props.height, this.props.width)}
-        </View>)
-    } else if (this.props.type == 'github') {
+          {this.renderMicrosoftButton(
+            this.props.text,
+            this.props.opacity,
+            this.props.height,
+            this.props.width
+          )}
+        </View>
+      );
+    } else if (this.props.type == "github") {
       return (
         <View>
-          {this.renderGithubButton(this.props.text, this.props.opacity, this.props.height, this.props.width)}
-        </View>)
-    }
-    else {
+          {this.renderGithubButton(
+            this.props.text,
+            this.props.opacity,
+            this.props.height,
+            this.props.width
+          )}
+        </View>
+      );
+    } else {
       return (
         <View>
-          {this.renderTwitterButton(this.props.text, this.props.opacity, this.props.height, this.props.width)}
-        </View>)
+          {this.renderTwitterButton(
+            this.props.text,
+            this.props.opacity,
+            this.props.height,
+            this.props.width
+          )}
+        </View>
+      );
     }
   }
 }
 
-
 const styles = StyleSheet.create({
   MainContainer: {
     flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    margin: 10,
+    justifyContent: "center",
+    alignItems: "center",
+    margin: 10
   },
   GooglePlusStyle: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: '#dc4e41',
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "#dc4e41",
     borderWidth: 0.5,
-    borderColor: '#fff',
+    borderColor: "#fff",
     height: 40,
     width: 220,
     borderRadius: 5,
-    margin: 5,
+    margin: 5
   },
   AmazonStyle: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: '#FF9B00',
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "#FF9B00",
     borderWidth: 0.5,
-    borderColor: '#fff',
+    borderColor: "#fff",
     height: 40,
     width: 220,
     borderRadius: 5,
-    margin: 5,
+    margin: 5
   },
   GithubStyle: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: '#333',
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "#333",
     borderWidth: 0.5,
-    borderColor: '#fff',
+    borderColor: "#fff",
     height: 40,
     width: 220,
     borderRadius: 5,
-    margin: 5,
+    margin: 5
   },
   FacebookStyle: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: '#485a96',
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "#485a96",
     borderWidth: 0.5,
-    borderColor: '#fff',
+    borderColor: "#fff",
     height: 40,
     width: 220,
     borderRadius: 5,
-    margin: 5,
+    margin: 5
   },
   LinkdnStyle: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: '#4875B4',
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "#4875B4",
     borderWidth: 0.5,
-    borderColor: '#fff',
+    borderColor: "#fff",
     height: 40,
     width: 220,
     borderRadius: 5,
-    margin: 5,
+    margin: 5
   },
   InstagramStyle: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: '#4E433C',
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "#4E433C",
     borderWidth: 0.5,
-    borderColor: '#fff',
+    borderColor: "#fff",
     height: 40,
     width: 220,
     borderRadius: 5,
-    margin: 5,
+    margin: 5
   },
   TwitterStyle: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: '#00acee',
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "#00acee",
     borderWidth: 0.5,
-    borderColor: '#fff',
+    borderColor: "#fff",
     height: 40,
     width: 220,
     borderRadius: 5,
-    margin: 5,
+    margin: 5
   },
   MicrosoftStyle: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: '#0078d7',
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "#0078d7",
     borderWidth: 0.5,
-    borderColor: '#fff',
+    borderColor: "#fff",
     height: 40,
     width: 220,
     borderRadius: 5,
-    margin: 5,
+    margin: 5
   },
   ImageIconStyle: {
     padding: 10,
     margin: 5,
     height: 25,
     width: 25,
-    resizeMode: 'stretch',
+    resizeMode: "stretch"
   },
   TextStyle: {
-    color: '#fff',
+    color: "#fff",
     marginBottom: 4,
-    marginRight: 20,
+    marginRight: 20
   },
   SeparatorLine: {
-    backgroundColor: '#fff',
+    backgroundColor: "#fff",
     width: 1,
-    height: 40,
-  },
+    height: 40
+  }
 });
-
-

--- a/src/SocialButtons.js
+++ b/src/SocialButtons.js
@@ -15,7 +15,7 @@ export default class SocialButton extends Component {
   renderFaceBookButton(buttonText, opacity, height, width) {
 
     return (
-      <TouchableOpacity style={[styles.FacebookStyle, { height, width }]} activeOpacity={opacity} onPress={this.props.action}>
+      <TouchableOpacity style={[styles.FacebookStyle, { height, width }]} activeOpacity={opacity} onPress={this.props.action} testID={this.props.testID}>
         <Image
           source={require('./images/facebook.png')}
           style={styles.ImageIconStyle}
@@ -28,7 +28,7 @@ export default class SocialButton extends Component {
 
   renderGoogleButton(buttonText, opacity, height, width) {
     return (
-      <TouchableOpacity style={[styles.GooglePlusStyle, { height, width }]} activeOpacity={opacity} onPress={this.props.action}>
+      <TouchableOpacity style={[styles.GooglePlusStyle, { height, width }]} activeOpacity={opacity} onPress={this.props.action} testID={this.props.testID}>
         <Image
           source={require('./images/google-plus.png')}
           style={styles.ImageIconStyle}
@@ -41,7 +41,7 @@ export default class SocialButton extends Component {
 
   renderGithubButton(buttonText, opacity, height, width) {
     return (
-      <TouchableOpacity style={[styles.GithubStyle, { height, width }]} activeOpacity={opacity} onPress={this.props.action}>
+      <TouchableOpacity style={[styles.GithubStyle, { height, width }]} activeOpacity={opacity} onPress={this.props.action} testID={this.props.testID}>
         <Image
           source={require('./images/github.png')}
           style={styles.ImageIconStyle}
@@ -54,7 +54,7 @@ export default class SocialButton extends Component {
 
   renderTwitterButton(buttonText, opacity, height, width) {
     return (
-      <TouchableOpacity style={[styles.TwitterStyle, { height, width }]} activeOpacity={opacity} onPress={this.props.action}>
+      <TouchableOpacity style={[styles.TwitterStyle, { height, width }]} activeOpacity={opacity} onPress={this.props.action} testID={this.props.testID}>
         <Image
           source={require('./images/twitter.png')}
           style={styles.ImageIconStyle}
@@ -67,7 +67,7 @@ export default class SocialButton extends Component {
 
   renderAmazonButton(buttonText, opacity, height, width) {
     return (
-      <TouchableOpacity style={[styles.AmazonStyle, { height, width }]} activeOpacity={opacity} onPress={this.props.action}>
+      <TouchableOpacity style={[styles.AmazonStyle, { height, width }]} activeOpacity={opacity} onPress={this.props.action} testID={this.props.testID}>
         <Image
           source={require('./images/amazon.png')}
           style={styles.ImageIconStyle}
@@ -80,7 +80,7 @@ export default class SocialButton extends Component {
 
   renderMicrosoftButton(buttonText, opacity, height, width) {
     return (
-      <TouchableOpacity style={[styles.MicrosoftStyle, { height, width }]} activeOpacity={opacity} onPress={this.props.action}>
+      <TouchableOpacity style={[styles.MicrosoftStyle, { height, width }]} activeOpacity={opacity} onPress={this.props.action} testID={this.props.testID}>
         <Image
           source={require('./images/windows.png')}
           style={styles.ImageIconStyle}
@@ -93,7 +93,7 @@ export default class SocialButton extends Component {
 
   renderLinkedinButton(buttonText, opacity, height, width) {
     return (
-      <TouchableOpacity style={[styles.LinkdnStyle, { height, width }]} activeOpacity={opacity} onPress={this.props.action}>
+      <TouchableOpacity style={[styles.LinkdnStyle, { height, width }]} activeOpacity={opacity} onPress={this.props.action} testID={this.props.testID}>
         <Image
           source={require('./images/linkedin.png')}
           style={styles.ImageIconStyle}

--- a/src/__tests__/SocialButtons-test.js
+++ b/src/__tests__/SocialButtons-test.js
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { render } from "@testing-library/react-native";
+import each from "jest-each";
+
+import SocialButtons from "../SocialButtons";
+
+describe("SocialButtons", () => {
+  it(`renders the basics`, async () => {
+    const renderer = render(<SocialButtons type="facebook" testID="test-id" />);
+    await renderer.getByTestId("test-id");
+    expect(renderer.toJSON()).toMatchSnapshot();
+  });
+
+  each([
+    "facebook",
+    "amazon",
+    "linkedin",
+    "google",
+    "microsoft",
+    "github",
+    "twitter"
+  ]).test(`render the button for %s`, async type => {
+    const renderer = render(
+      <SocialButtons type={type} testID={`${type}-button`} />
+    );
+    await renderer.getByTestId(`${type}-button`);
+  });
+});

--- a/src/__tests__/__snapshots__/SocialButtons-test.js.snap
+++ b/src/__tests__/__snapshots__/SocialButtons-test.js.snap
@@ -1,0 +1,569 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SocialButtons render the login for amazon 1`] = `
+<View>
+  <View
+    accessible={true}
+    collapsable={false}
+    focusable={false}
+    nativeID="animatedComponent"
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#FF9B00",
+        "borderColor": "#fff",
+        "borderRadius": 5,
+        "borderWidth": 0.5,
+        "flexDirection": "row",
+        "height": undefined,
+        "margin": 5,
+        "opacity": 1,
+        "width": undefined,
+      }
+    }
+    testID="amazon-button"
+  >
+    <Image
+      source={
+        Object {
+          "testUri": "../../../src/images/amazon.png",
+        }
+      }
+      style={
+        Object {
+          "height": 25,
+          "margin": 5,
+          "padding": 10,
+          "resizeMode": "stretch",
+          "width": 25,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "height": 40,
+          "width": 1,
+        }
+      }
+    />
+    <Text
+      style={
+        Object {
+          "color": "#fff",
+          "marginBottom": 4,
+          "marginRight": 20,
+        }
+      }
+    >
+       
+       
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`SocialButtons render the login for facebook 1`] = `
+<View>
+  <View
+    accessible={true}
+    collapsable={false}
+    focusable={false}
+    nativeID="animatedComponent"
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#485a96",
+        "borderColor": "#fff",
+        "borderRadius": 5,
+        "borderWidth": 0.5,
+        "flexDirection": "row",
+        "height": undefined,
+        "margin": 5,
+        "opacity": 1,
+        "width": undefined,
+      }
+    }
+    testID="facebook-button"
+  >
+    <Image
+      source={
+        Object {
+          "testUri": "../../../src/images/facebook.png",
+        }
+      }
+      style={
+        Object {
+          "height": 25,
+          "margin": 5,
+          "padding": 10,
+          "resizeMode": "stretch",
+          "width": 25,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "height": 40,
+          "width": 1,
+        }
+      }
+    />
+    <Text
+      style={
+        Object {
+          "color": "#fff",
+          "marginBottom": 4,
+          "marginRight": 20,
+        }
+      }
+    >
+       
+       
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`SocialButtons render the login for github 1`] = `
+<View>
+  <View
+    accessible={true}
+    collapsable={false}
+    focusable={false}
+    nativeID="animatedComponent"
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#333",
+        "borderColor": "#fff",
+        "borderRadius": 5,
+        "borderWidth": 0.5,
+        "flexDirection": "row",
+        "height": undefined,
+        "margin": 5,
+        "opacity": 1,
+        "width": undefined,
+      }
+    }
+    testID="github-button"
+  >
+    <Image
+      source={
+        Object {
+          "testUri": "../../../src/images/github.png",
+        }
+      }
+      style={
+        Object {
+          "height": 25,
+          "margin": 5,
+          "padding": 10,
+          "resizeMode": "stretch",
+          "width": 25,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "height": 40,
+          "width": 1,
+        }
+      }
+    />
+    <Text
+      style={
+        Object {
+          "color": "#fff",
+          "marginBottom": 4,
+          "marginRight": 20,
+        }
+      }
+    >
+       
+       
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`SocialButtons render the login for google 1`] = `
+<View>
+  <View
+    accessible={true}
+    collapsable={false}
+    focusable={false}
+    nativeID="animatedComponent"
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#dc4e41",
+        "borderColor": "#fff",
+        "borderRadius": 5,
+        "borderWidth": 0.5,
+        "flexDirection": "row",
+        "height": undefined,
+        "margin": 5,
+        "opacity": 1,
+        "width": undefined,
+      }
+    }
+    testID="google-button"
+  >
+    <Image
+      source={
+        Object {
+          "testUri": "../../../src/images/google-plus.png",
+        }
+      }
+      style={
+        Object {
+          "height": 25,
+          "margin": 5,
+          "padding": 10,
+          "resizeMode": "stretch",
+          "width": 25,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "height": 40,
+          "width": 1,
+        }
+      }
+    />
+    <Text
+      style={
+        Object {
+          "color": "#fff",
+          "marginBottom": 4,
+          "marginRight": 20,
+        }
+      }
+    >
+       
+       
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`SocialButtons render the login for linkedin 1`] = `
+<View>
+  <View
+    accessible={true}
+    collapsable={false}
+    focusable={false}
+    nativeID="animatedComponent"
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#4875B4",
+        "borderColor": "#fff",
+        "borderRadius": 5,
+        "borderWidth": 0.5,
+        "flexDirection": "row",
+        "height": undefined,
+        "margin": 5,
+        "opacity": 1,
+        "width": undefined,
+      }
+    }
+    testID="linkedin-button"
+  >
+    <Image
+      source={
+        Object {
+          "testUri": "../../../src/images/linkedin.png",
+        }
+      }
+      style={
+        Object {
+          "height": 25,
+          "margin": 5,
+          "padding": 10,
+          "resizeMode": "stretch",
+          "width": 25,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "height": 40,
+          "width": 1,
+        }
+      }
+    />
+    <Text
+      style={
+        Object {
+          "color": "#fff",
+          "marginBottom": 4,
+          "marginRight": 20,
+        }
+      }
+    >
+       
+       
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`SocialButtons render the login for microsoft 1`] = `
+<View>
+  <View
+    accessible={true}
+    collapsable={false}
+    focusable={false}
+    nativeID="animatedComponent"
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#0078d7",
+        "borderColor": "#fff",
+        "borderRadius": 5,
+        "borderWidth": 0.5,
+        "flexDirection": "row",
+        "height": undefined,
+        "margin": 5,
+        "opacity": 1,
+        "width": undefined,
+      }
+    }
+    testID="microsoft-button"
+  >
+    <Image
+      source={
+        Object {
+          "testUri": "../../../src/images/windows.png",
+        }
+      }
+      style={
+        Object {
+          "height": 25,
+          "margin": 5,
+          "padding": 10,
+          "resizeMode": "stretch",
+          "width": 25,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "height": 40,
+          "width": 1,
+        }
+      }
+    />
+    <Text
+      style={
+        Object {
+          "color": "#fff",
+          "marginBottom": 4,
+          "marginRight": 20,
+        }
+      }
+    >
+       
+       
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`SocialButtons render the login for twitter 1`] = `
+<View>
+  <View
+    accessible={true}
+    collapsable={false}
+    focusable={false}
+    nativeID="animatedComponent"
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#00acee",
+        "borderColor": "#fff",
+        "borderRadius": 5,
+        "borderWidth": 0.5,
+        "flexDirection": "row",
+        "height": undefined,
+        "margin": 5,
+        "opacity": 1,
+        "width": undefined,
+      }
+    }
+    testID="twitter-button"
+  >
+    <Image
+      source={
+        Object {
+          "testUri": "../../../src/images/twitter.png",
+        }
+      }
+      style={
+        Object {
+          "height": 25,
+          "margin": 5,
+          "padding": 10,
+          "resizeMode": "stretch",
+          "width": 25,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "height": 40,
+          "width": 1,
+        }
+      }
+    />
+    <Text
+      style={
+        Object {
+          "color": "#fff",
+          "marginBottom": 4,
+          "marginRight": 20,
+        }
+      }
+    >
+       
+       
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`SocialButtons renders the basics 1`] = `
+<View>
+  <View
+    accessible={true}
+    collapsable={false}
+    focusable={false}
+    nativeID="animatedComponent"
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      Object {
+        "alignItems": "center",
+        "backgroundColor": "#485a96",
+        "borderColor": "#fff",
+        "borderRadius": 5,
+        "borderWidth": 0.5,
+        "flexDirection": "row",
+        "height": undefined,
+        "margin": 5,
+        "opacity": 1,
+        "width": undefined,
+      }
+    }
+    testID="test-id"
+  >
+    <Image
+      source={
+        Object {
+          "testUri": "../../../src/images/facebook.png",
+        }
+      }
+      style={
+        Object {
+          "height": 25,
+          "margin": 5,
+          "padding": 10,
+          "resizeMode": "stretch",
+          "width": 25,
+        }
+      }
+    />
+    <View
+      style={
+        Object {
+          "backgroundColor": "#fff",
+          "height": 40,
+          "width": 1,
+        }
+      }
+    />
+    <Text
+      style={
+        Object {
+          "color": "#fff",
+          "marginBottom": 4,
+          "marginRight": 20,
+        }
+      }
+    >
+       
+       
+    </Text>
+  </View>
+</View>
+`;

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
-import SocialButton  from "./SocialButtons";
+import SocialButton from "./SocialButtons";
 
 export default SocialButton;


### PR DESCRIPTION
To support downstream testing of auth-flows (where we use these buttons) it is useful to be able to set the `testID` prop on the `TouchableOpacity` buttons.

This patch enables the prop to be passed through to the render

ADDITIONALLY: We add testing via jest and the "@testing-library/react-native" library.